### PR TITLE
Removed user password reset

### DIFF
--- a/configuration/init.toml
+++ b/configuration/init.toml
@@ -137,15 +137,6 @@
     [Module.Command]
         Cmd = ["/bin/zsh", "-c", 'version="$(sysctl -n kern.osproductversion)";sed -i "" "s/macOS.*/macOS $(echo -e "10.14 Mojave\n10.15 Catalina\n11.0 Big Sur" | grep ^$(echo $version | cut -d"." -f1-2)| cut -d" " -f2-) $version/" /etc/motd'] # Update /etc/motd
 
-# Remove SSH group, if it exists
-[[Module]]
-    Name = "RemoveSSHGroup"
-    PriorityGroup = 2 # Second group
-    RunOnce = true # Run only on the first boot
-    FatalOnError = false # Best effort, don't fatal on error
-    [Module.Command]
-        Cmd = ["/bin/zsh", "-c", "dscl /Local/Default delete /Groups/com.apple.access_ssh || true"] # Use dscl to delete group
-
 # Disable WiFi
 [[Module]]
     Name = "DisableWiFi"


### PR DESCRIPTION
There is a limited number of attempts of the unattended password set for a user with `dscl ` command. Once they depleted, `dscl` command requires entering the previous user password explicitly.
The forced setting of a random password with `dscl ` command on the first launch does not make much sense because it's still impossible to ScreenShare to the system when there is no password. But that action (force password set) just subtracts the password reset attempt from the total number of possible unattended resets, which makes troubleshooting and custom provisioning a bit more difficult.


*Description of changes:*
- removed force password reset for a user


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
