### PR TITLE
Add User Management Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,26 @@ the use of `sysctl` and `defaults`.
       value = "false"
 ```
 
+
+### User Management
+The `UserManagement` module provides the ability to safely randomize an existing user's password. 
+
+* `User` (`string`) - Optional; The user (which must already exist) to manage. Default is `ec2-user`.
+* `RandomizePassword` (`bool`) - Optional; Configures whether the user's password should be randomized 
+  on first boot. Default is `true`.
+  
+#### Example
+```toml
+[[Module]]
+  Name = "ManageEC2User"
+  PriorityGroup = 2 # Second group
+  RunOnce = true # Run only on the first boot
+  FatalOnError = true # Must succeed
+  [Module.UserManagement]
+    User = "ec2-user" # This user must exist locally in /Users/
+    RandomizePassword = true # default is true
+```
+
 ## Building
 
 The `build.sh` script has been provided for easy builds.  This script sets build-time variables, gets dependencies, 

--- a/configuration/init.toml
+++ b/configuration/init.toml
@@ -102,12 +102,13 @@
 
 # Set a random password for ec2-user
 [[Module]]
-    Name = "SetEC2UserPassword"
+    Name = "ManageEC2User"
     PriorityGroup = 2 # Second group
     RunOnce = true # Run only on the first boot
     FatalOnError = true # Must succeed
-    [Module.Command]
-        Cmd = ["/bin/zsh", "-c", "/usr/bin/dscl . -passwd /Users/ec2-user $(openssl rand -base64 18)"] # Set random password
+    [Module.UserManagement]
+        User = "ec2-user" # This user must exist locally in /Users/
+        RandomizePassword = true # default is true
 
 # Set timezone as GMT
 [[Module]]

--- a/lib/ec2macosinit/module.go
+++ b/lib/ec2macosinit/module.go
@@ -10,19 +10,20 @@ import (
 // Module contains a few fields common to all Module types and containers for the configuration of any
 // potential module type.
 type Module struct {
-	Type               string
-	Success            bool
-	Name               string             `toml:"Name"`
-	PriorityGroup      int                `toml:"PriorityGroup"`
-	FatalOnError       bool               `toml:"FatalOnError"`
-	RunOnce            bool               `toml:"RunOnce"`
-	RunPerBoot         bool               `toml:"RunPerBoot"`
-	RunPerInstance     bool               `toml:"RunPerInstance"`
-	CommandModule      CommandModule      `toml:"Command"`
-	SSHKeysModule      SSHKeysModule      `toml:"SSHKeys"`
-	UserDataModule     UserDataModule     `toml:"UserData"`
-	NetworkCheckModule NetworkCheckModule `toml:"NetworkCheck"`
-	SystemConfigModule SystemConfigModule `toml:"SystemConfig"`
+	Type                 string
+	Success              bool
+	Name                 string               `toml:"Name"`
+	PriorityGroup        int                  `toml:"PriorityGroup"`
+	FatalOnError         bool                 `toml:"FatalOnError"`
+	RunOnce              bool                 `toml:"RunOnce"`
+	RunPerBoot           bool                 `toml:"RunPerBoot"`
+	RunPerInstance       bool                 `toml:"RunPerInstance"`
+	CommandModule        CommandModule        `toml:"Command"`
+	SSHKeysModule        SSHKeysModule        `toml:"SSHKeys"`
+	UserDataModule       UserDataModule       `toml:"UserData"`
+	NetworkCheckModule   NetworkCheckModule   `toml:"NetworkCheck"`
+	SystemConfigModule   SystemConfigModule   `toml:"SystemConfig"`
+	UserManagementModule UserManagementModule `toml:"UserManagement"`
 }
 
 // ModuleContext contains fields that may need to be passed to the Do function for modules.
@@ -79,6 +80,10 @@ func (m *Module) identifyModule() (err error) {
 	}
 	if !cmp.Equal(m.SystemConfigModule, SystemConfigModule{}) {
 		m.Type = "systemconfig"
+		return nil
+	}
+	if !cmp.Equal(m.UserManagementModule, UserManagementModule{}) {
+		m.Type = "usermanagement"
 		return nil
 	}
 

--- a/lib/ec2macosinit/usermanagement.go
+++ b/lib/ec2macosinit/usermanagement.go
@@ -1,0 +1,185 @@
+package ec2macosinit
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"path"
+	"strings"
+)
+
+const (
+	// PasswordLength is the default number of characters that the auto-generated password should be
+	PasswordLength = 25
+	// DsclPath is the default path for the dscl utility needed for the functions in this file
+	DsclPath = "/usr/bin/dscl"
+)
+
+// UserManagementModule contains the necessary values to run a User Management Module
+type UserManagementModule struct {
+	RandomizePassword bool   `toml:"RandomizePassword"`
+	User              string `toml:"User"`
+}
+
+// Do for the UserManagementModule is the primary entry point for the User Management Module.
+func (c *UserManagementModule) Do(ctx *ModuleContext) (message string, err error) {
+	// Check if randomizing password is requested. If so, then perform action, otherwise return with no work to do
+	if c.RandomizePassword {
+		message, err = c.randomizePassword()
+		if err != nil {
+			return "", fmt.Errorf("ec2macosinit: failed to randomize password: %s", err)
+		}
+	} else {
+		return fmt.Sprint("randomizing password disabled, skipping"), nil
+	}
+
+	// For now, `message` will only be set if RandomizePassword is true. Instead of returning above, it is returned here
+	// for readability and future additions to the module
+	return message, nil
+}
+
+// isSecureTokenSet wraps the sysadminctl call to provide a bool for checking if its enabled
+// The way to detect if the Secure Token is set for a user is `sysadminctl`, here is an example for ec2-user:
+//     /usr/sbin/sysadminctl -secureTokenStatus ec2-user
+//     2021-01-14 18:17:47.414 sysadminctl[96836:904874] Secure token is DISABLED for user ec2-user
+// When enabled it shows:
+//     2021-01-14 19:21:55.854 sysadminctl[14193:181530] Secure token is ENABLED for user ec2-user
+func (c *UserManagementModule) isSecureTokenSet() (enabled bool, err error) {
+	// Fetch the text from the built-in tool sysadminctl
+	statusText, err := executeCommand([]string{"/usr/sbin/sysadminctl", "-secureTokenStatus", c.User}, "", []string{})
+	if err != nil {
+		return false, fmt.Errorf("ec2macosinit: unable to get Secure Token status for %s: %s", c.User, err)
+	}
+	// If the text has "ENABLED" then return true, otherwise return false
+	if strings.Contains(statusText.stdout, "Secure token is ENABLED") {
+		return true, nil
+	}
+	return false, nil
+}
+
+// disableSecureTokenCreation disables the default behavior to enable the Secure Token on the next user password change.
+// From https://support.apple.com/guide/deployment-reference-macos/using-secure-and-bootstrap-tokens-apdff2cf769b/web
+// This is the command used to avoid setting the SecureToken when changing the password
+//     /usr/bin/dscl . append /Users/ec2-user AuthenticationAuthority ";DisabledTags;SecureToken"
+func (c *UserManagementModule) disableSecureTokenCreation() (err error) {
+	_, err = executeCommand([]string{DsclPath, ".", "append", path.Join("Users", c.User), "AuthenticationAuthority", ";DisabledTags;SecureToken"}, "", []string{})
+	if err != nil {
+		return fmt.Errorf("ec2macosinit: failed disable Secure Token creation: %s", err)
+	}
+	return nil
+}
+
+// enableSecureTokenCreation enables the default behavior to enable the Secure Token on the next user password change.
+// From https://support.apple.com/guide/deployment-reference-macos/using-secure-and-bootstrap-tokens-apdff2cf769b/web
+// This is the command used to remove the setting for the SecureToken when changing the password
+//     /usr/bin/dscl . delete /Users/ec2-user AuthenticationAuthority ";DisabledTags;SecureToken"
+func (c *UserManagementModule) enableSecureTokenCreation() (err error) {
+	_, err = executeCommand([]string{DsclPath, ".", "delete", path.Join("Users", c.User), "AuthenticationAuthority", ";DisabledTags;SecureToken"}, "", []string{})
+	if err != nil {
+		return fmt.Errorf("ec2macosinit: failed to disable Secure Token creation: %s", err)
+	}
+	return nil
+}
+
+// changePassword changes the password to a provided string.
+func (c *UserManagementModule) changePassword(password string) (err error) {
+	_, err = executeCommand([]string{DsclPath, ".", "-passwd", path.Join("Users", c.User), password}, "", []string{})
+	if err != nil {
+		return fmt.Errorf("ec2macosinit: failed to set %s's password: %s", c.User, err)
+	}
+	return nil
+}
+
+// randomizePassword confirms if the Secure Token is set and randomizes the user password.
+// The password change functionality, at its core, is simply detecting if the user password can be randomized for
+// the default "ec2-user" user. The complexity comes in when dealing with the Secure Token. From Big Sur onward, the
+// Secure Token is set on all initial password changes, this is not ideal since future password changes would require
+// knowing this random password. This process is built to avoid the Secure Token being set on this first randomization.
+// The basic flow is:
+//   1. Check for the Secure Token already being set which would prevent changing the password
+//   2. Add a special property to avoid the Secure Token from being set
+//   3. Change the password to a random string
+//   4. Undo the special property so that the next password change will set the Secure Token
+func (c *UserManagementModule) randomizePassword() (message string, err error) {
+	// This detection of the user probably needs to move into the Do() function when there is more to do, but since this
+	// is the first place the c.User is used, its handled here
+	// If user is undefined, default to ec2-user
+	if c.User == "" {
+		c.User = "ec2-user"
+	}
+
+	// Verify that user exists
+	exists, err := userExists(c.User)
+	if err != nil {
+		return "", fmt.Errorf("ec2macosinit: error while checking if user %s exists: %s\n", c.User, err)
+	}
+	if !exists { // if the user doesn't exist, error out
+		return "", fmt.Errorf("ec2macosinit: user %s does not exist\n", c.User)
+	}
+
+	// Check for Secure Token, if its already set then attempting to change the password will fail
+	secureTokenSet, err := c.isSecureTokenSet()
+	if err != nil {
+		return "", fmt.Errorf("ec2macosinit: unable to confirm Secure Token is DISABLED: %s", err)
+	}
+
+	// Only proceed if user doesn't have Secure Token enabled
+	if secureTokenSet {
+		return "", fmt.Errorf("ec2macosinit: unable to change password, Secure Token Set for %s", c.User)
+	}
+
+	// Change Secure Token behavior if needed
+	err = c.disableSecureTokenCreation()
+	if err != nil {
+		return "", fmt.Errorf("ec2macosinit: unable to disable Secure Token generation: %s", err)
+	}
+	defer func() {
+		// Set Secure Token behavior back if needed
+		deferErr := c.enableSecureTokenCreation()
+		if deferErr != nil {
+			// Catch a failure and change status returns to represent an error condition
+			message = "" // Overwrite new message to indicate error
+			err = fmt.Errorf("ec2macosinit: unable to enable Secure Token generation: %s %s", deferErr, err)
+		}
+	}()
+
+	// Generate random password
+	password, err := generateSecurePassword(PasswordLength)
+	if err != nil {
+		return "", fmt.Errorf("ec2macosinit: unable to generate secure password: %s", err)
+	}
+
+	// Change the password
+	err = c.changePassword(password)
+	if err != nil {
+		return "", fmt.Errorf("ec2macosinit: unable to set secure password: %s", err)
+	}
+
+	return fmt.Sprintf("successfully set secure password for %s", c.User), nil
+}
+
+// generateRandomBytes returns securely generated random bytes for use in generating a password
+// It will return an error if the system's secure random number generator fails to function correctly
+func generateRandomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, fmt.Errorf("ec2macosinit: unable to read random bytes from OS: %s", err)
+	}
+
+	return b, nil
+}
+
+// generateSecurePassword generates a password securely for use in randomizePassword using the crypto/rand library
+func generateSecurePassword(length int) (password string, err error) {
+	// Fetch the requested number of bytes, this ensures at least that much entropy
+	randomBytes, err := generateRandomBytes(length)
+	if err != nil {
+		return "", fmt.Errorf("ec2macosinit: unable to generate secure password %s", err)
+	}
+	// URLEncode it to have safe characters for passwords
+	source := base64.URLEncoding.EncodeToString(randomBytes)
+
+	// Return only the length requested since URL Encoding can result in longer strings
+	return source[0:length], nil
+}

--- a/lib/ec2macosinit/usermanagement_test.go
+++ b/lib/ec2macosinit/usermanagement_test.go
@@ -1,0 +1,114 @@
+package ec2macosinit
+
+import (
+	"testing"
+)
+
+func TestUserManagementModule_Do(t *testing.T) {
+	var emptyCtx ModuleContext
+	type fields struct {
+		RandomizePassword bool
+		User              string
+	}
+	type args struct {
+		ctx *ModuleContext
+	}
+	tests := []struct {
+		name        string
+		fields      fields
+		args        args
+		wantMessage string
+		wantErr     bool
+	}{
+		{"No Randomization", fields{RandomizePassword: false, User: "ec2-user"}, args{&emptyCtx}, "randomizing password disabled, skipping", false},
+		{"User doesn't exist", fields{RandomizePassword: true, User: "thereisnowaythisusercouldexist"}, args{&emptyCtx}, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &UserManagementModule{
+				RandomizePassword: tt.fields.RandomizePassword,
+				User:              tt.fields.User,
+			}
+			gotMessage, err := c.Do(tt.args.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Do() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotMessage != tt.wantMessage {
+				t.Errorf("Do() gotMessage = %v, want %v", gotMessage, tt.wantMessage)
+			}
+		})
+	}
+}
+
+func Test_generateRandomBytes(t *testing.T) {
+	type args struct {
+		n int
+	}
+	tests := []struct {
+		name          string
+		args          args
+		exampleResult []byte
+		wantErr       bool
+	}{
+		{"Basic case", args{18}, []byte{'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', '=', '='}, false},
+		{"Slice of 1", args{1}, []byte{'A'}, false},
+		{"Empty case", args{0}, []byte{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := generateRandomBytes(tt.args.n)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("generateRandomBytes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			// Check that length is correct, since its random, no more can be done without adjusting seeding
+			if len(got) != len(tt.exampleResult) {
+				t.Errorf("generateRandomBytes() length of got = %d, want %d", len(got), len(tt.exampleResult))
+			}
+		})
+	}
+}
+
+func Test_generateSecurePassword(t *testing.T) {
+	type args struct {
+		length int
+	}
+	tests := []struct {
+		name            string
+		args            args
+		examplePassword string
+		wantErr         bool
+	}{
+		// Randomly create some tests, run the same one over and over to ensure seeding is working
+		{"Basic case 1", args{25}, "Qfmk0rD8HAq3zZD37hvs41234", false},
+		{"Basic case 2", args{25}, "5iWL3MoeSTQ0ILk4hC4s43214", false},
+		{"Basic case 3", args{25}, "y0pFxuh_sTp1qhp_WCv3w4afd", false},
+		{"Basic case 4", args{25}, "q2yogfL6JCDntj9cYfdszda35", false},
+		{"Basic case 5", args{25}, "TI29Yhy32f3tZtsj42q34rCgG", false},
+		{"Basic case 6", args{25}, "4Y0FGvwsFcCm-2QtadfzR9324", false},
+		{"Short password", args{6}, "Ad8-3S", false},
+	}
+	// Build a map that will detect duplicates
+	repeatedResults := make(map[string]bool)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPassword, err := generateSecurePassword(tt.args.length)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("generateSecurePassword() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			// Check that length is correct, since its random, no more can be done without adjusting seeding
+			if len(gotPassword) != len(tt.examplePassword) {
+				t.Errorf("generateSecurePassword() length of gotPassword = %d, wantPassword %v", len(gotPassword), len(tt.examplePassword))
+			}
+			// Add to the map for detecting duplicates
+			repeatedResults[gotPassword] = true
+		})
+	}
+	// Fail if there are fewer deduplicated passwords than tests
+	if len(repeatedResults) < len(tests) {
+		t.Errorf("generateSecurePassword() collision detected: length of unique passwords: %d, number of tests: %d", len(repeatedResults), len(tests))
+	}
+}

--- a/run.go
+++ b/run.go
@@ -103,6 +103,8 @@ func run(c *ec2macosinit.InitConfig) {
 						message, err = m.NetworkCheckModule.Do(ctx)
 					case "systemconfig":
 						message, err = m.SystemConfigModule.Do(ctx)
+					case "usermanagement":
+						message, err = m.UserManagementModule.Do(ctx)
 					default:
 						message = "unknown module type"
 						err = fmt.Errorf("unknown module type")


### PR DESCRIPTION
Big Sur requires extra care for changing the default user password. The
ideal approach is to now guard against accidental setting of the Secure
Token while changing the password. This is now accomplished in the User
Management Module.

*Issue #, if available:*
NA

*Description of changes:*
This adds in the UserManagement Module which allows safer setting of the user password on first boot.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
