### PR TITLE
build: add development targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pkg
 .DS_Store
 commitdate.txt
 version.txt
+ec2-macos-init*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+go = go
+goimports = go run golang.org/x/tools/cmd/goimports@latest
+PKGPATH=$(shell go list -m)
+T=$(PKGPATH)/...
+
+.DEFAULT: release
+
+.PHONY: release
+release:: build test ec2-macos-init
+
+ec2-macos-init ec2-macos-init_amd64 ec2-macos-init_arm64 &:
+	./build.sh
+
+.PHONY: build
+build:
+	$(go) build $(V) $(T)
+
+.PHONY: test
+test:
+	$(go) test $(V) $(T)
+
+.PHONY: imports goimports
+imports goimports:
+	$(goimports) -local $(PKGPATH) $(or $(goimports_flags),-w) .
+
+.PHONY: clean
+clean::
+	$(go) clean -i
+	git clean -fX

--- a/build.sh
+++ b/build.sh
@@ -1,21 +1,31 @@
-#!/bin/bash
-set -e
-set -o pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 
-echo "Building EC2 macOS Init..."
+log() { echo "> $*" >&2; }
+
+if ! hash lipo 2>/dev/null; then
+    log "unable to build universal binary without 'lipo' (macOS only)"
+    exit 1
+fi
+
+log "building EC2 macOS Init..."
 
 # Get commit date and version tag
-COMMITDATE=$(git show -s --format=%ci HEAD)
-VERSION=$(git describe --always --tags)
-echo -e "Commit date: ${COMMITDATE}"
-echo -e "Version: ${VERSION}"
+COMMITDATE="$(git show -s --format=%ci HEAD)"
+VERSION="$(git describe --always --tags)"
 
-# Build for darwin/amd64
-echo "Running go build..."
+log "Commit date: ${COMMITDATE}"
+log "Version: ${VERSION}"
 
 for arch in amd64 arm64; do
-    GOOS=darwin GOARCH="$arch" CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X 'main.CommitDate=${COMMITDATE}' -X 'main.Version=${VERSION}'" -o "ec2-macos-init_$arch"
+    log "building for darwin/$arch"
+    GOOS=darwin GOARCH="$arch" CGO_ENABLED=0 \
+        go build -trimpath \
+        -ldflags="-s -w -X 'main.CommitDate=${COMMITDATE}' -X 'main.Version=${VERSION}'" \
+        -o "ec2-macos-init_$arch"
 done
-lipo -create -output ec2-macos-init ec2-macos-init_amd64 ec2-macos-init_arm64
 
-echo "Build complete"
+lipo -create -output ec2-macos-init \
+    ec2-macos-init_amd64 ec2-macos-init_arm64
+
+log "Build complete"

--- a/lib/ec2macosinit/util_test.go
+++ b/lib/ec2macosinit/util_test.go
@@ -2,11 +2,12 @@ package ec2macosinit
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_ioReadCloserToString(t *testing.T) {


### PR DESCRIPTION


*Description of changes:*

- development targets in a new `Makefile`
- minor improvements to build script
- `goimports` formatted sources (yay, only one!)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
