### PR TITLE
chore: ignore noisy commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+d079dbffd36833e7ceb595da11a3d0802a50ebb8


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This adds large format changing commits (like in this PR) to GitHub's filtered out set of commits when clicking through blames.

https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
