### PR TITLE
fix: remove deprecated launchd job key

### DIFF
--- a/Library/LaunchDaemons/com.amazon.ec2.macos-init.plist
+++ b/Library/LaunchDaemons/com.amazon.ec2.macos-init.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Debug</key>
-	<true/>
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

This removes the `Debug` setting from the `ec2-macos-init` launchd job as currently (on Ventura) the launchd logs indicate the `Debug` key is deprecated.

```
2022-10-24 10:49:38.031943 (com.amazon.ec2.macos-init) <Error>: The Debug key is no longer respected. Please remove it.
```

I checked the open source releases of `launchd` to see if there's more context but couldn't find a comment in the available artifacts. That said, the `man` pages don't include a deprecation message, but clearly the `launchd` process thinks they're deprecated (see logs above). I'm inclined to trust the source (of launchd) here. 

- https://opensource.apple.com/tarballs/launchd/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
