### PR TITLE
refactor: drop networksetup downif command

### DIFF
--- a/configuration/init.toml
+++ b/configuration/init.toml
@@ -17,15 +17,6 @@
 ### Group 1 ###
 ## Making sure unnecessary resources are disabled
 
-# Disable Ethernet
-[[Module]]
-    Name = "DisableEthernet"
-    PriorityGroup = 1 # First group
-    RunPerBoot = true # Run every boot
-    FatalOnError = true # Fatal if there's an error - this must succeed
-    [Module.Command]
-        Cmd = ["/usr/sbin/networksetup", "-setnetworkserviceenabled", "Ethernet", "off"]
-
 # Unmount Local SSD
 [[Module]]
     Name = "UnmountLocalSSD"


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

The network interfaces are setup by other packages' LaunchDaemon jobs and this command may conflict with their logic and configuration (which may differ by instance type - eg: mac1.metal vs mac2.metal).

We drop the command here in favor of these other tools as they're more accurately tuned for the specific instance types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
