### PR TITLE
feat: add safe write functionality

### DIFF
--- a/lib/ec2macosinit/instancehistory.go
+++ b/lib/ec2macosinit/instancehistory.go
@@ -39,7 +39,16 @@ func (c *InitConfig) GetInstanceHistory() (err error) {
 	for _, dir := range dirs {
 		if dir.IsDir() {
 			historyFile := filepath.Join(c.HistoryPath, dir.Name(), c.HistoryFilename)
-			if _, err := os.Stat(historyFile); err == nil {
+			if info, err := os.Stat(historyFile); err == nil {
+				// Check to make sure info is a file and not a directory.
+				if !info.Mode().IsRegular() {
+					continue
+				}
+				// If there is an error getting the history file or if the history file is empty do not append to Instance History
+				if info.Size() == 0 {
+					c.Log.Warnf("The history file exists at %s but is empty. Skipping this file...", historyFile)
+					continue
+				}
 				history, err := readHistoryFile(historyFile)
 				if err != nil {
 					return fmt.Errorf("ec2macosinit: error while reading history file at %s: %w", historyFile, err)

--- a/lib/ec2macosinit/instancehistory.go
+++ b/lib/ec2macosinit/instancehistory.go
@@ -26,6 +26,22 @@ type ModuleHistory struct {
 	Success bool   `json:"success"`
 }
 
+// HistoryError wraps a normal error and gives the caller insight into the type of error.
+// The caller can check the type of error and handle different types of error differently.
+// Currently HistoryError only handles errors for invalid JSON but the struct is flexible
+// and can be adjusted to handle several different errors differently.
+type HistoryError struct {
+	err error
+}
+
+func (h HistoryError) Unwrap() error {
+	return h.err
+}
+
+func (h HistoryError) Error() string {
+	return h.err.Error()
+}
+
 // GetInstanceHistory takes a path to instance history directory and a file name for history files and searches for
 // any files that match. Then, for each file, it calls readHistoryFile() to read the file and add it to the
 // InstanceHistory struct.
@@ -73,7 +89,7 @@ func readHistoryFile(file string) (history History, err error) {
 	// Unmarshal to struct
 	err = json.Unmarshal(historyBytes, &history)
 	if err != nil {
-		return History{}, fmt.Errorf("ec2macosinit: error unmarshaling history from JSON: %w", err)
+		return History{}, HistoryError{err: err}
 	}
 
 	return history, nil

--- a/lib/ec2macosinit/instancehistory.go
+++ b/lib/ec2macosinit/instancehistory.go
@@ -33,7 +33,7 @@ func (c *InitConfig) GetInstanceHistory() (err error) {
 	// Read instance history directory
 	dirs, err := ioutil.ReadDir(c.HistoryPath)
 	if err != nil {
-		return fmt.Errorf("ec2macosinit: unable to read instance history directory: %s\n", err)
+		return fmt.Errorf("ec2macosinit: unable to read instance history directory: %w", err)
 	}
 	// For each directory, check for a history file and call readHistoryFile()
 	for _, dir := range dirs {
@@ -42,7 +42,7 @@ func (c *InitConfig) GetInstanceHistory() (err error) {
 			if _, err := os.Stat(historyFile); err == nil {
 				history, err := readHistoryFile(historyFile)
 				if err != nil {
-					return fmt.Errorf("ec2macosinit: error while reading history file at %s: %s\n", historyFile, err)
+					return fmt.Errorf("ec2macosinit: error while reading history file at %s: %w", historyFile, err)
 				}
 				// Append the returned History struct to the InstanceHistory slice
 				c.InstanceHistory = append(c.InstanceHistory, history)
@@ -58,13 +58,13 @@ func readHistoryFile(file string) (history History, err error) {
 	// Read file
 	historyBytes, err := ioutil.ReadFile(file)
 	if err != nil {
-		return History{}, fmt.Errorf("ec2macosinit: error reading config file located at %s: %s\n", file, err)
+		return History{}, fmt.Errorf("ec2macosinit: error reading config file located at %s: %w", file, err)
 	}
 
 	// Unmarshal to struct
 	err = json.Unmarshal(historyBytes, &history)
 	if err != nil {
-		return History{}, fmt.Errorf("ec2macosinit: error unmarshaling history from JSON: %s\n", err)
+		return History{}, fmt.Errorf("ec2macosinit: error unmarshaling history from JSON: %w", err)
 	}
 
 	return history, nil
@@ -93,22 +93,46 @@ func (c *InitConfig) WriteHistoryFile() (err error) {
 	// Marshal to JSON
 	historyBytes, err := json.Marshal(history)
 	if err != nil {
-		return fmt.Errorf("ec2macosinit: unable to write history file: %s\n", err)
+		return fmt.Errorf("ec2macosinit: unable to write history file: %w", err)
 	}
 
 	// Ensure the path exists and create it if it doesn't
 	err = c.CreateDirectories()
 	if err != nil {
-		return fmt.Errorf("ec2macosinit: unable to write history file: :%s\n", err)
+		return fmt.Errorf("ec2macosinit: unable to write history file: :%w", err)
 	}
 
 	// Write history JSON file
-	err = ioutil.WriteFile(filepath.Join(c.HistoryPath, c.IMDS.InstanceID, c.HistoryFilename), historyBytes, 0644)
+	path := filepath.Join(c.HistoryPath, c.IMDS.InstanceID, c.HistoryFilename)
+	err = safeWrite(path, historyBytes)
 	if err != nil {
-		return fmt.Errorf("ec2macosinit: unable to write history file: %s\n", err)
+		return fmt.Errorf("ec2macosinit: unable to write history file: %w", err)
 	}
 
 	return nil
+}
+
+// safeWrite writes data to the desired file path or not at all. This function
+// protects against partially written or unflushed data intended for the file.
+func safeWrite(path string, data []byte) error {
+	f, err := os.CreateTemp(filepath.Dir(path), fmt.Sprintf(".%s.*", filepath.Base(path)))
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	_, err = f.Write(data)
+	if err != nil {
+		return err
+	}
+
+	err = f.Sync()
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(f.Name(), path)
 }
 
 // CreateDirectories creates the instance directory, if it doesn't exist and a directory for the running instance.
@@ -116,7 +140,7 @@ func (c *InitConfig) CreateDirectories() (err error) {
 	if _, err := os.Stat(filepath.Join(c.HistoryPath, c.IMDS.InstanceID)); os.IsNotExist(err) {
 		err := os.MkdirAll(filepath.Join(c.HistoryPath, c.IMDS.InstanceID), 0755)
 		if err != nil {
-			return fmt.Errorf("ec2macosinit: unable to create directory: %s\n", err)
+			return fmt.Errorf("ec2macosinit: unable to create directory: %w", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Added functionality to write safely to files. The history file would sometimes have a partial write leaving the history file created but empty, causing ec2-macos-init to not be able to parse the history file.*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
