### PR TITLE
fix: usage of path, replaced with filepath

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -34,7 +34,7 @@ func clean(c *ec2macosinit.InitConfig) {
 		}
 		for _, d := range dir {
 			// Remove everything
-			err := os.RemoveAll(filepath.Join([]string{historyPath, d.Name()}...))
+			err := os.RemoveAll(filepath.Join(historyPath, d.Name()))
 			if err != nil {
 				c.Log.Fatalf(1, "Unable to remove instance history: %s", err)
 			}

--- a/clean.go
+++ b/clean.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/aws/ec2-macos-init/lib/ec2macosinit"
 )
@@ -24,7 +24,7 @@ func clean(c *ec2macosinit.InitConfig) {
 	}
 
 	// Clean all or clean the current instance
-	historyPath := path.Join(baseDir, instanceHistoryDir)
+	historyPath := filepath.Join(baseDir, instanceHistoryDir)
 	if *cleanAll {
 		c.Log.Info("Removing all instance history")
 		// Read instance history directory
@@ -34,7 +34,7 @@ func clean(c *ec2macosinit.InitConfig) {
 		}
 		for _, d := range dir {
 			// Remove everything
-			err := os.RemoveAll(path.Join([]string{historyPath, d.Name()}...))
+			err := os.RemoveAll(filepath.Join([]string{historyPath, d.Name()}...))
 			if err != nil {
 				c.Log.Fatalf(1, "Unable to remove instance history: %s", err)
 			}
@@ -49,7 +49,7 @@ func clean(c *ec2macosinit.InitConfig) {
 		c.Log.Infof("Removing history for the current instance [%s]", c.IMDS.InstanceID)
 
 		// Remove current instance history
-		err := os.RemoveAll(path.Join(historyPath, c.IMDS.InstanceID))
+		err := os.RemoveAll(filepath.Join(historyPath, c.IMDS.InstanceID))
 		if err != nil {
 			c.Log.Fatalf(1, "Unable to remove instance history: %s", err)
 		}

--- a/lib/ec2macosinit/instancehistory.go
+++ b/lib/ec2macosinit/instancehistory.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 )
 
@@ -38,7 +38,7 @@ func (c *InitConfig) GetInstanceHistory() (err error) {
 	// For each directory, check for a history file and call readHistoryFile()
 	for _, dir := range dirs {
 		if dir.IsDir() {
-			historyFile := path.Join(c.HistoryPath, dir.Name(), c.HistoryFilename)
+			historyFile := filepath.Join(c.HistoryPath, dir.Name(), c.HistoryFilename)
 			if _, err := os.Stat(historyFile); err == nil {
 				history, err := readHistoryFile(historyFile)
 				if err != nil {
@@ -103,7 +103,7 @@ func (c *InitConfig) WriteHistoryFile() (err error) {
 	}
 
 	// Write history JSON file
-	err = ioutil.WriteFile(path.Join(c.HistoryPath, c.IMDS.InstanceID, c.HistoryFilename), historyBytes, 0644)
+	err = ioutil.WriteFile(filepath.Join(c.HistoryPath, c.IMDS.InstanceID, c.HistoryFilename), historyBytes, 0644)
 	if err != nil {
 		return fmt.Errorf("ec2macosinit: unable to write history file: %s\n", err)
 	}
@@ -113,8 +113,8 @@ func (c *InitConfig) WriteHistoryFile() (err error) {
 
 // CreateDirectories creates the instance directory, if it doesn't exist and a directory for the running instance.
 func (c *InitConfig) CreateDirectories() (err error) {
-	if _, err := os.Stat(path.Join(c.HistoryPath, c.IMDS.InstanceID)); os.IsNotExist(err) {
-		err := os.MkdirAll(path.Join(c.HistoryPath, c.IMDS.InstanceID), 0755)
+	if _, err := os.Stat(filepath.Join(c.HistoryPath, c.IMDS.InstanceID)); os.IsNotExist(err) {
+		err := os.MkdirAll(filepath.Join(c.HistoryPath, c.IMDS.InstanceID), 0755)
 		if err != nil {
 			return fmt.Errorf("ec2macosinit: unable to create directory: %s\n", err)
 		}

--- a/lib/ec2macosinit/sshkeys.go
+++ b/lib/ec2macosinit/sshkeys.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -40,8 +40,8 @@ func (c *SSHKeysModule) Do(ctx *ModuleContext) (message string, err error) {
 	}
 
 	// Set directory and authorized_keys file
-	authorizedKeysDir := path.Join("/Users", c.User, ".ssh")
-	authorizedKeysFile := path.Join(authorizedKeysDir, "authorized_keys")
+	authorizedKeysDir := filepath.Join("/Users", c.User, ".ssh")
+	authorizedKeysFile := filepath.Join(authorizedKeysDir, "authorized_keys")
 	if _, err := os.Stat(authorizedKeysDir); os.IsNotExist(err) { // If directory doesn't exist, create it
 		err := os.MkdirAll(authorizedKeysDir, 0700)
 		if err != nil {

--- a/lib/ec2macosinit/userdata.go
+++ b/lib/ec2macosinit/userdata.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -43,7 +43,7 @@ func (c *UserDataModule) Do(ctx *ModuleContext) (message string, err error) {
 	}
 
 	// Write user data to file
-	userDataFile := path.Join(baseDir, ctx.IMDS.InstanceID, fileName)
+	userDataFile := filepath.Join(baseDir, ctx.IMDS.InstanceID, fileName)
 	f, err := os.OpenFile(userDataFile, os.O_CREATE|os.O_WRONLY, 0755)
 	if err != nil {
 		return "", fmt.Errorf("ec2macosinit: error while opening user data file: %s\n", err)

--- a/lib/ec2macosinit/usermanagement.go
+++ b/lib/ec2macosinit/usermanagement.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -62,7 +62,7 @@ func (c *UserManagementModule) isSecureTokenSet() (enabled bool, err error) {
 // This is the command used to avoid setting the SecureToken when changing the password
 //     /usr/bin/dscl . append /Users/ec2-user AuthenticationAuthority ";DisabledTags;SecureToken"
 func (c *UserManagementModule) disableSecureTokenCreation() (err error) {
-	_, err = executeCommand([]string{DsclPath, ".", "append", path.Join("Users", c.User), "AuthenticationAuthority", ";DisabledTags;SecureToken"}, "", []string{})
+	_, err = executeCommand([]string{DsclPath, ".", "append", filepath.Join("Users", c.User), "AuthenticationAuthority", ";DisabledTags;SecureToken"}, "", []string{})
 	if err != nil {
 		return fmt.Errorf("ec2macosinit: failed disable Secure Token creation: %s", err)
 	}
@@ -74,7 +74,7 @@ func (c *UserManagementModule) disableSecureTokenCreation() (err error) {
 // This is the command used to remove the setting for the SecureToken when changing the password
 //     /usr/bin/dscl . delete /Users/ec2-user AuthenticationAuthority ";DisabledTags;SecureToken"
 func (c *UserManagementModule) enableSecureTokenCreation() (err error) {
-	_, err = executeCommand([]string{DsclPath, ".", "delete", path.Join("Users", c.User), "AuthenticationAuthority", ";DisabledTags;SecureToken"}, "", []string{})
+	_, err = executeCommand([]string{DsclPath, ".", "delete", filepath.Join("Users", c.User), "AuthenticationAuthority", ";DisabledTags;SecureToken"}, "", []string{})
 	if err != nil {
 		return fmt.Errorf("ec2macosinit: failed to disable Secure Token creation: %s", err)
 	}
@@ -83,7 +83,7 @@ func (c *UserManagementModule) enableSecureTokenCreation() (err error) {
 
 // changePassword changes the password to a provided string.
 func (c *UserManagementModule) changePassword(password string) (err error) {
-	_, err = executeCommand([]string{DsclPath, ".", "-passwd", path.Join("Users", c.User), password}, "", []string{})
+	_, err = executeCommand([]string{DsclPath, ".", "-passwd", filepath.Join("Users", c.User), password}, "", []string{})
 	if err != nil {
 		return fmt.Errorf("ec2macosinit: failed to set %s's password: %s", c.User, err)
 	}

--- a/run.go
+++ b/run.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -34,7 +34,7 @@ func run(c *ec2macosinit.InitConfig) {
 
 	// Read init config
 	c.Log.Info("Reading init config...")
-	err = c.ReadConfig(path.Join(baseDir, configFile))
+	err = c.ReadConfig(filepath.Join(baseDir, configFile))
 	if err != nil {
 		c.Log.Fatalf(computeExitCode(c, 66), "Error while reading init config file: %s", err)
 	}


### PR DESCRIPTION
*Issue #23*

*Description of changes:*

- used ```filepath``` package instead of ```path``` package for joining file paths.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
