### PR TITLE
fix: detect module even when false is set

### DIFF
--- a/lib/ec2macosinit/module_test.go
+++ b/lib/ec2macosinit/module_test.go
@@ -6,6 +6,12 @@ import (
 	"time"
 )
 
+// values used via pointers in module configs
+var (
+	trueValue  = true
+	falseValue = false
+)
+
 func TestModule_validateModule(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -102,6 +108,35 @@ func TestModule_identifyModule(t *testing.T) {
 			},
 			wantType: "networkcheck",
 			wantErr:  false,
+		},
+		{
+			name: "Good case: Enable secureSSHDConfig",
+			fields: Module{
+				SystemConfigModule: SystemConfigModule{
+					SecureSSHDConfig: &trueValue,
+				},
+			},
+			wantType: "systemconfig",
+			wantErr:  false,
+		},
+		{
+			name: "Good case: Disable secureSSHDConfig",
+			fields: Module{
+				SystemConfigModule: SystemConfigModule{
+					SecureSSHDConfig: &falseValue,
+				},
+			},
+			wantType: "systemconfig",
+			wantErr:  false,
+		},
+		{
+			name: "Bad case: don't provide secureSSHDConfig",
+			fields: Module{
+				SystemConfigModule: SystemConfigModule{
+					SecureSSHDConfig: nil,
+				},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/lib/ec2macosinit/systemconfig.go
+++ b/lib/ec2macosinit/systemconfig.go
@@ -57,7 +57,7 @@ type ModifyDefaults struct {
 
 // SystemConfigModule contains all necessary configuration fields for running a System Configuration module.
 type SystemConfigModule struct {
-	SecureSSHDConfig bool             `toml:"secureSSHDConfig"`
+	SecureSSHDConfig *bool            `toml:"secureSSHDConfig"`
 	ModifySysctl     []ModifySysctl   `toml:"Sysctl"`
 	ModifyDefaults   []ModifyDefaults `toml:"Defaults"`
 }
@@ -69,7 +69,7 @@ func (c *SystemConfigModule) Do(ctx *ModuleContext) (message string, err error) 
 
 	// Secure SSHD configuration
 	var sshdConfigChanges, sshdUnchanged, sshdErrors int32
-	if c.SecureSSHDConfig {
+	if c.SecureSSHDConfig != nil && *c.SecureSSHDConfig {
 		wg.Add(1)
 		go func() {
 			err := writeEC2SSHConfigs()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This was tripping up on false being a zero value. When comparing (with cmp) against the zero value of the struct, the _desired_ value is confused with the zero value.

Now the module uses a pointer to detect whether or not a value has been set to handle the case that `false` is the intended setting.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
