### PR TITLE
Add support for macOS Sequoia in the MOTD module

### DIFF
--- a/lib/ec2macosinit/motd.go
+++ b/lib/ec2macosinit/motd.go
@@ -84,6 +84,8 @@ func getVersionName(osProductVersion string) (versionName string) {
 		versionName = "Ventura"
 	case strings.HasPrefix(osProductVersion, "14"):
 		versionName = "Sonoma"
+	case strings.HasPrefix(osProductVersion, "15"):
+		versionName = "Sequoia"
 	}
 
 	return versionName


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change updates the MOTD module to support macOS Sequoia (15.x).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
