### PR TITLE
Remove defaults configuration to rely on baked in preferences

### DIFF
--- a/configuration/init.toml
+++ b/configuration/init.toml
@@ -1,4 +1,4 @@
-# Default EC2 macOS Init init.toml config for mac1.metal instances
+# Default EC2 macOS Init init.toml config
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
@@ -36,7 +36,7 @@
         Cmd = ["/bin/zsh", "-c", "diskutil list internal physical | egrep -o '^/dev/disk\\d+' | xargs diskutil eject || true"]
 
 ### Group 2 ###
-## The only task in the first group is to make sure the network is up.  Some of the subsequent actions require
+## The only task in this group is to make sure the network is up.  Some of the subsequent actions require
 ## a connection to IMDS and will fail if this check doesn't pass.
 
 # Checks that the network is up
@@ -49,7 +49,7 @@
         PingCount = 3 # Three attempts
 
 ### Group 3 ###
-## The second group has many actions that can be run in parallel including:
+## This group has many actions that can be run in parallel including:
 ##   1. Optimize kernel and networking parameters
 ##   2. Disable auto-update
 ##   3. Apply suggested SSHD security settings
@@ -86,31 +86,6 @@
             value = "net.inet.tcp.recvspace=1048576"
         [[Module.SystemConfig.Sysctl]]
             value = "net.link.generic.system.rcvq_maxlen=1024"
-        [[Module.SystemConfig.Defaults]]
-            plist = "/Library/Preferences/com.apple.SoftwareUpdate.plist"
-            parameter = "AutomaticallyInstallMacOSUpdates"
-            type = "bool"
-            value = "false"
-        [[Module.SystemConfig.Defaults]]
-            plist = "/Library/Preferences/com.apple.SoftwareUpdate.plist"
-            parameter = "AutomaticCheckEnabled"
-            type = "bool"
-            value = "false"
-        [[Module.SystemConfig.Defaults]]
-            plist = "/Library/Preferences/com.apple.SoftwareUpdate.plist"
-            parameter = "AutomaticDownload"
-            type = "bool"
-            value = "false"
-        [[Module.SystemConfig.Defaults]]
-            plist = "/Library/Preferences/com.apple.SoftwareUpdate.plist"
-            parameter = "CriticalUpdateInstall"
-            type = "bool"
-            value = "false"
-        [[Module.SystemConfig.Defaults]]
-            plist = "/Library/Preferences/com.apple.SoftwareUpdate.plist"
-            parameter = "ConfigDataInstall"
-            type = "bool"
-            value = "false"
 
 # Apply secure settings to SSHD on every boot
 # To manage ssh_config separately, disable this module

--- a/configuration/init_toml_check_test.go
+++ b/configuration/init_toml_check_test.go
@@ -1,0 +1,24 @@
+package main_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/ec2-macos-init/lib/ec2macosinit"
+)
+
+// Load and test the current copy of init.toml to ensure it remains
+// loadable and valid for use in packaging.
+
+func TestConfiguration_initTOML(t *testing.T) {
+	var loadedConfig ec2macosinit.InitConfig
+
+	loadErr := loadedConfig.ReadConfig("./init.toml")
+	assert.NoError(t, loadErr, "should be able to load config file")
+	require.NotEmpty(t, loadedConfig.Modules, "should have modules configured")
+
+	validateErr := loadedConfig.ValidateAndIdentify()
+	assert.NoError(t, validateErr, "should have valid modules")
+}


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

This change removes the `defaults` now set and persisted in image build activities.

Also added a cheap check of the `init.toml` that's committed to validate ahead of packaging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
