### PR TITLE
systemconfig: ensure temporary sshd_config_fixed is removed

### DIFF
--- a/lib/ec2macosinit/systemconfig.go
+++ b/lib/ec2macosinit/systemconfig.go
@@ -349,6 +349,7 @@ func (c *SystemConfigModule) configureSSHD(ctx *ModuleContext) (configChanges bo
 	if err != nil {
 		return false, fmt.Errorf("ec2macosinit: error creating %s", tempSSHDFile.Name())
 	}
+	defer os.Remove(tempSSHDFile.Name())
 	defer tempSSHDFile.Close()
 
 	// Keep track of line number simply for confirming warning header
@@ -441,6 +442,7 @@ func (c *SystemConfigModule) configureSSHD(ctx *ModuleContext) (configChanges bo
 		}
 
 		// Move the temporary file to the SSHDConfigFile
+		tempSSHDFile.Close()
 		err = os.Rename(tempSSHDFile.Name(), sshdConfigFile)
 		if err != nil {
 			return false, fmt.Errorf("ec2macosinit: unable to save updated configuration to %s", sshdConfigFile)


### PR DESCRIPTION
#21 

Fix issue with configureSSHD not removing temporary file when it returns early.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
